### PR TITLE
fix(ci): add pull-requests: read to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}


### PR DESCRIPTION
## Summary

- Adds `pull-requests: read` permission to the CD job in `publish.yml`

`cd.yml@ci-cd-workflows/v7.3.1` internally requests `pull-requests: read`. Without it, GitHub Actions rejects the workflow with:

> Error calling workflow '...cd.yml@ci-cd-workflows/v7.3.1'. The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.

