### PR TITLE
feat(ci): stamp changelog with version and date on CD publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,31 @@ on:
 permissions: {}
 
 jobs:
+  stamp-changelog:
+    name: Stamp changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Replace [Unreleased] with version and date
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          DATE=$(date -u +%Y-%m-%d)
+          sed -i "s/## \[Unreleased\]/## [$VERSION] - $DATE/" CHANGELOG.md
+      - name: Commit changelog stamp
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --staged --quiet || git commit -m "chore: stamp changelog for release"
+          git push
+
   cd:
     name: CD
+    needs: stamp-changelog
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated Playwright Docker image to v1.59.1-noble.
 - CI now runs Playwright against Grafana `>=12.3`, including the
   dev and React 19 preview images.
+- CD workflow (`publish.yml`) now stamps `[Unreleased]` in `CHANGELOG.md`
+  with the version from `package.json` and today's UTC date before the
+  plugin is published.
 
 ### Internal
 


### PR DESCRIPTION
## Summary

- Add a `stamp-changelog` job to `publish.yml` that runs before the `cd` job and replaces `## [Unreleased]` in
  `CHANGELOG.md` with the version from `package.json` and today's UTC date.
- The commit is skipped if `[Unreleased]` is not present (idempotent via `git diff --staged --quiet`), so
  re-running the workflow on an already-stamped changelog is safe.
- The `cd` job gains a `needs: stamp-changelog` dependency so it always picks up the stamped commit.

See [Release 3.6.3](https://grafana.com/grafana/plugins/volkovlabs-table-panel/?tab=changelog) to see what happened before.  We will need to replicate this to other repos, and possibly enhance the ci-cd workflows to include it.

### CI/CD

- `publish.yml`: new `stamp-changelog` job checks out the target branch, stamps the changelog, and pushes before
  `plugin-ci-workflows` cd.yml runs.

## Test plan

- [ ] Trigger the CD workflow manually against a branch that has `## [Unreleased]` in `CHANGELOG.md` and verify
      the section is replaced with `## [X.Y.Z] - YYYY-MM-DD` and committed before the plugin is packaged.
- [ ] Trigger the CD workflow a second time on the same branch (already stamped) and verify no extra commit is
      created and the workflow completes successfully.
- [ ] Trigger the CD workflow against a branch with no `## [Unreleased]` section and verify it completes without
      error.