### PR TITLE
ci: migrate publish workflow to changelog validation, bump vitest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,13 +59,13 @@ jobs:
 
       - name: Coverage report (with comparison)
         if: steps.base-coverage.outcome == 'success'
-        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           json-summary-compare-path: /tmp/base-coverage/coverage-summary.json
           file-coverage-mode: all
 
       - name: Coverage report (PR only)
         if: steps.base-coverage.outcome != 'success'
-        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           file-coverage-mode: all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,41 +23,38 @@ on:
 permissions: {}
 
 jobs:
-  stamp-changelog:
-    name: Stamp changelog
+  check-changelog:
+    name: Check changelog
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      contents: read
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
-        with:
-          github_app: grafana-plugins-platform-bot
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.branch }}
-          token: ${{ steps.app-token.outputs.token }}
-      - name: Replace [Unreleased] with version and date
+      - name: Verify CHANGELOG.md has no [Unreleased] section
         run: |
-          grep -q "## \[Unreleased\]" CHANGELOG.md || { echo "No [Unreleased] heading found \ already stamped?"; exit 1; }
-          VERSION=$(node -p "require('./package.json').version")
-          DATE=$(date -u +%Y-%m-%d)
-          sed -i "s/## \[Unreleased\]/## [$VERSION] - $DATE/" CHANGELOG.md
-      - name: Commit changelog stamp
-        env:
-          BRANCH: ${{ github.event.inputs.branch }}
-        run: |
-          git config user.name 'grafana-plugins-platform-bot[bot]'
-          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
-          git add CHANGELOG.md
-          git diff --staged --quiet || git commit -m "chore: stamp changelog for release"
-          git push origin HEAD:$BRANCH
+          UNRELEASED_LINE=$(grep -n "^## \[Unreleased\]" CHANGELOG.md | head -1 | cut -d: -f1)
+          RELEASE_LINE=$(grep -n "^## \[[0-9]" CHANGELOG.md | head -1 | cut -d: -f1)
+
+          # No [Unreleased] section — nothing to check
+          if [ -z "$UNRELEASED_LINE" ]; then
+            exit 0
+          fi
+
+          # [Unreleased] is below the latest release — fine
+          if [ -n "$RELEASE_LINE" ] && [ "$UNRELEASED_LINE" -gt "$RELEASE_LINE" ]; then
+            exit 0
+          fi
+
+          VERSION=$(jq -r '.version' package.json)
+          echo "Error: CHANGELOG.md contains an [Unreleased] section."
+          echo "A released version is required and must match package.json (${VERSION})."
+          exit 1
 
   cd:
     name: CD
-    needs: stamp-changelog
+    needs: check-changelog
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Migrated publish workflow from auto-stamping changelog to pre-flight changelog validation.
 - Bumped `vitest-coverage-report-action` to v2.12.0.
 
-## [3.6.4] - 2026-05-20
-
-### Project Updates
-
-- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
-
 ## [3.6.4] - 2026-04-30
 
 ### Fixed
@@ -49,6 +43,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added pull request coverage and file-changes summary reports.
 - Updated development documentation.
 - Updated development scripts and tooling.
+- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
 
 ## [3.6.0] - 2025-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the **Business Table Panel** plugin for Grafana are docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Project Updates
+
+- Migrated publish workflow from auto-stamping changelog to pre-flight changelog validation.
+- Bumped `vitest-coverage-report-action` to v2.12.0.
+
 ## [3.6.4] - 2026-05-20
 
 ### Project Updates


### PR DESCRIPTION
### CI/CD

- `publish.yml`: Simplify the publish workflow — instead of automatically stamping and committing a changelog entry at publish time,
  the workflow now verifies the changelog is already stamped before proceeding.

### Dependencies

- `coverage.yml`: Bump `vitest-coverage-report-action` to v2.12.0 (both report steps updated).

## Test plan

- [ ] Trigger publish on a branch with a stamped `CHANGELOG.md` — workflow passes
- [ ] Trigger publish on a branch with an `[Unreleased]` section still present — workflow fails with a clear error
- [ ] Confirm the `cd` job runs after the changelog check passes