### PR TITLE
fix(FilterPopup): filter closing on operator select in Grafana 12.3+

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -56,6 +56,7 @@
     "autosize",
     "Dockerfiles",
     "buildx",
-    "Locize"
+    "Locize",
+    "menuitemradio"
   ]
 }

--- a/src/components/Table/components/FilterPopup/FilterPopup.test.tsx
+++ b/src/components/Table/components/FilterPopup/FilterPopup.test.tsx
@@ -103,6 +103,29 @@ describe('FilterPopup', () => {
     expect(selectors.root()).toBeInTheDocument();
   });
 
+  /**
+   * The popup element itself must reach FilterSection, so portaled menus render inside the ClickOutsideWrapper subtree.
+   */
+  it('Should pass the popup container down as menuRoot', () => {
+    render(
+      getComponent({
+        header: {
+          column: {
+            getFilterValue: () => undefined,
+            columnDef: {
+              meta: {},
+            },
+          },
+        } as any,
+      })
+    );
+
+    expect(jest.mocked(FilterSection)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ menuRoot: selectors.root() }),
+      expect.anything()
+    );
+  });
+
   it('Should allow to reset filter', () => {
     const setFilterValue = jest.fn();
 

--- a/src/components/Table/components/FilterPopup/FilterPopup.tsx
+++ b/src/components/Table/components/FilterPopup/FilterPopup.tsx
@@ -61,6 +61,11 @@ export const FilterPopup = <TData,>({
   );
 
   /**
+   * Popup Container
+   */
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+
+  /**
    * Filter Mode
    */
   const filterMode = header.column.columnDef.meta?.filterMode || ColumnFilterMode.CLIENT;
@@ -149,6 +154,7 @@ export const FilterPopup = <TData,>({
   return (
     <ClickOutsideWrapper onClick={onClose} useCapture={true}>
       <div
+        ref={setContainer}
         className={styles.filterPopup}
         onClick={(event) => event.stopPropagation()}
         {...TEST_IDS.filterPopup.root.apply()}
@@ -162,6 +168,7 @@ export const FilterPopup = <TData,>({
           onChange={(value) => setFilter(value)}
           onSave={onSave}
           filterMode={filterMode}
+          menuRoot={container ?? undefined}
         />
         <div className={styles.filterPopupLine} />
         <div className={styles.filterPopupFooter}>

--- a/src/components/Table/components/FilterSection/FilterSection.tsx
+++ b/src/components/Table/components/FilterSection/FilterSection.tsx
@@ -159,7 +159,9 @@ export const FilterSection = <TData,>({
       {filter.type === ColumnFilterType.FACETED && (
         <FilterFacetedList value={filter} onChange={onChange} header={header} />
       )}
-      {filter.type === ColumnFilterType.NUMBER && <FilterNumber value={filter} onChange={onChange} menuRoot={menuRoot} />}
+      {filter.type === ColumnFilterType.NUMBER && (
+        <FilterNumber value={filter} onChange={onChange} menuRoot={menuRoot} />
+      )}
       {filter.type === ColumnFilterType.TIMESTAMP && <FilterTime value={filter} onChange={onChange} />}
     </div>
   );

--- a/src/components/Table/components/FilterSection/FilterSection.tsx
+++ b/src/components/Table/components/FilterSection/FilterSection.tsx
@@ -54,6 +54,13 @@ interface Props<TData> {
    * @type {boolean}
    */
   autoFocus: boolean;
+
+  /**
+   * Menu Root
+   *
+   * @type {HTMLElement}
+   */
+  menuRoot?: HTMLElement;
 }
 
 /**
@@ -68,6 +75,7 @@ export const FilterSection = <TData,>({
   setFilter,
   filterMode,
   autoFocus,
+  menuRoot,
 }: Props<TData>) => {
   /**
    * Styles
@@ -151,7 +159,7 @@ export const FilterSection = <TData,>({
       {filter.type === ColumnFilterType.FACETED && (
         <FilterFacetedList value={filter} onChange={onChange} header={header} />
       )}
-      {filter.type === ColumnFilterType.NUMBER && <FilterNumber value={filter} onChange={onChange} />}
+      {filter.type === ColumnFilterType.NUMBER && <FilterNumber value={filter} onChange={onChange} menuRoot={menuRoot} />}
       {filter.type === ColumnFilterType.TIMESTAMP && <FilterTime value={filter} onChange={onChange} />}
     </div>
   );

--- a/src/components/Table/components/FilterSection/components/FilterNumber/FilterNumber.test.tsx
+++ b/src/components/Table/components/FilterSection/components/FilterNumber/FilterNumber.test.tsx
@@ -1,3 +1,4 @@
+import { ButtonSelect } from '@grafana/ui';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { getJestSelectors } from '@/utils/test-selectors';
 import React from 'react';
@@ -71,6 +72,22 @@ describe('FilterNumber', () => {
       ...value,
       value: [15, 0],
     });
+  });
+
+  /**
+   * Grafana 12.3+ renders the ButtonSelect menu through a Portal. Unless it is portaled into
+   * the filter popup, clicking an operator registers as a click outside and closes the popup
+   * before the selection applies.
+   */
+  it('Should portal the operator menu into menuRoot', () => {
+    const menuRoot = document.createElement('div');
+
+    render(getComponent({ menuRoot }));
+
+    expect(jest.mocked(ButtonSelect)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ root: menuRoot }),
+      expect.anything()
+    );
   });
 
   it('Should hide additional value if not between operator', () => {

--- a/src/components/Table/components/FilterSection/components/FilterNumber/FilterNumber.tsx
+++ b/src/components/Table/components/FilterSection/components/FilterNumber/FilterNumber.tsx
@@ -22,12 +22,22 @@ interface Props {
    * Change
    */
   onChange: (value: Value) => void;
+
+  /**
+   * Menu Root
+   *
+   * Element the operator menu portals into. Keeps the menu inside the filter popup so
+   * clicking an option is not treated as a click outside.
+   *
+   * @type {HTMLElement}
+   */
+  menuRoot?: HTMLElement;
 }
 
 /**
  * Filter Number
  */
-export const FilterNumber: React.FC<Props> = ({ value: filterValue, onChange }) => {
+export const FilterNumber: React.FC<Props> = ({ value: filterValue, onChange, menuRoot }) => {
   return (
     <InlineFieldRow>
       <ButtonSelect
@@ -42,6 +52,7 @@ export const FilterNumber: React.FC<Props> = ({ value: filterValue, onChange }) 
           });
         }}
         value={{ value: filterValue.operator }}
+        root={menuRoot}
         {...TEST_IDS.filterNumber.fieldOperator.apply()}
       />
       <InlineField>

--- a/test/panel.spec.ts
+++ b/test/panel.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
+import { NumberFilterOperator } from '../src/types';
 import { PanelHelper } from './utils';
 
 test.describe('Business Table Panel', () => {
@@ -441,6 +442,31 @@ test.describe('Business Table Panel', () => {
       await filter.applyNumberValue(14);
 
       await table.checkBodyRowsCount(2);
+    });
+
+    test('Should keep the filter popup open when selecting a numeric operator', async ({
+      gotoDashboardPage,
+      readProvisionedDashboard,
+    }) => {
+      const dashboard = await readProvisionedDashboard({ fileName: 'panels.json' });
+      const dashboardPage = await gotoDashboardPage({ uid: dashboard.uid });
+
+      const panel = new PanelHelper(dashboardPage, 'Table');
+      const table = panel.getTable();
+
+      await table.getHeaderRow().getHeaderCell('value').checkIfFilterable();
+      await table.checkBodyRowsCount(3);
+
+      /**
+       * Switching the operator to "<" must not dismiss the popup, and the value typed
+       * afterwards must apply against that operator: value < 14 leaves only 10.
+       */
+      const filter = table.getHeaderRow().getHeaderCell('value').getFilter();
+      await filter.open();
+      await filter.selectNumberOperator(NumberFilterOperator.LESS);
+      await filter.fillNumberValueAndSave(14);
+
+      await table.checkBodyRowsCount(1);
     });
   });
 

--- a/test/utils/table.ts
+++ b/test/utils/table.ts
@@ -36,13 +36,35 @@ class TableFilterHelper {
     return this.popupSelectors.buttonSave().click();
   }
 
-  public async applyNumberValue(value: string | number) {
-    await this.open();
+  /**
+   * Select an operator from the ButtonSelect and assert the popup survives it.
+   *
+   * Grafana 12.3+ portals the ButtonSelect menu out of the popup, so without the
+   * menuRoot wiring the click reads as a click outside and closes the popup before
+   * the operator applies.
+   */
+  public async selectNumberOperator(operator: string) {
+    const numberSelectors = getLocatorSelectors(TEST_IDS.filterNumber)(this.popupSelectors.root());
+    const page = this.popupSelectors.root().page();
+
+    await numberSelectors.fieldOperator().click();
+    await page.getByRole('menuitemradio', { name: operator, exact: true }).click();
+
+    await expect(this.popupSelectors.root()).toBeVisible();
+    return expect(numberSelectors.fieldOperator()).toHaveText(operator);
+  }
+
+  public async fillNumberValueAndSave(value: string | number) {
     const numberSelectors = getLocatorSelectors(TEST_IDS.filterNumber)(this.popupSelectors.root());
     const field = numberSelectors.fieldValue();
     await field.fill(String(value));
     await field.blur();
     return this.popupSelectors.buttonSave().click();
+  }
+
+  public async applyNumberValue(value: string | number) {
+    await this.open();
+    return this.fillNumberValueAndSave(value);
   }
 }
 


### PR DESCRIPTION
With Grafana 12.3+ the `FilterPopup` component closes on click of the operator dropdown elements.
This fix simply sets the `menuRoot` which fixes the bug. 

Fixes: https://github.com/grafana/business-table/issues/112