### PR TITLE
fix(CD): upgrade plugin-ci-workflows to 10.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
   cd:
     name: CD
     needs: check-changelog
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.2.0
     permissions:
       contents: write
       id-token: write
@@ -65,5 +65,7 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
+      # See plugin-ci-workflows#815.
+      attestation: true
       signature-type: community
       run-playwright: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,5 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      attestation: true
       signature-type: community
       run-playwright: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.2.0
     permissions:
       contents: read
       pull-requests: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Project Updates
 
-- Bumped `plugin-ci-workflows` to `ci-cd-workflows/v10.0.1`.
+- Bumped `plugin-ci-workflows` to `ci-cd-workflows/v10.2.0`.
 - Disabled Renovate major-version bump pull requests.
 - Bumped `semver` to v7.8.4.
 


### PR DESCRIPTION
CD failed at catalog publish here: https://github.com/grafana/business-table/actions/runs/33002314172/job/98287953773#step:10:98

Upgrading to 10.0.1 in https://github.com/grafana/business-table/pull/114 was an attempt to avoid the react 19 cutoff, but it had a bug requiring the removing of attestation.
So now we need to upgrade to 10.2, and we'll need to workaround potential e2e breakages.