### PR TITLE
release: 3.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the **Business Table Panel** plugin for Grafana are docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.6] - 2026-08-26
+## [3.6.7] - 2026-08-27
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "volkovlabs-table-panel",
   "description": "Simplify data visualization in table format",
-  "version": "3.6.6",
+  "version": "3.6.7",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
[3.6.6](https://github.com/grafana/business-table/pull/113) deploy tried to go out during the github outage yesterday, let's see if a new release works better.